### PR TITLE
Use Sha2 crate for hashing instead of system dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "netrc",
  "openssl",
  "reqwest",
+ "sha2",
  "strfmt",
  "tokio",
  "tokio-util",
@@ -134,6 +135,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +223,35 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "generic-array",
+]
 
 [[package]]
 name = "dotenv"
@@ -349,6 +388,16 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1055,6 +1104,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d964dd36bb15bcf2f2b35694c072feab74969a54f2bbeec7a2d725d2bdcb6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1328,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "typenum"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1394,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ indicatif = "0.16.2"
 netrc = "0.4.1"
 openssl = { version = "0.10", features = ["vendored"] }
 reqwest = { version = "0.11.3", features = ["stream"] }
+sha2 = "0.10.0"
 strfmt = "0.1.6"
 tokio = { version = "1.14.0", features = ["full"] }
 tokio-util = {version="0.6.9", features = ["full"]}

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,5 +1,7 @@
-use std::process::Command;
 use std::str;
+
+use sha2::{Digest, Sha256};
+use std::{fs, io};
 
 pub struct HashChecker;
 impl HashChecker {
@@ -25,16 +27,36 @@ impl HashChecker {
     }
 
     fn sha256sum(filename: &str) -> String {
-        let computed_hash: String = str::from_utf8(
-            &Command::new("sh")
-                .arg("-c")
-                .arg(&("sha256sum ".to_string() + filename + "| cut -d' ' -f1 | tr -d '\n'"))
-                .output()
-                .expect("failed to execute process")
-                .stdout,
-        )
-        .unwrap()
-        .to_string();
-        computed_hash
+        let mut hasher = Sha256::new();
+        let mut file = fs::File::open(filename).unwrap();
+
+        io::copy(&mut file, &mut hasher).unwrap();
+        let computed_hash = hasher.finalize();
+
+        format!("{:x}", computed_hash)
     }
+}
+
+#[test]
+fn test_sha256sum_api() {
+    let expected = "0352bbf93e78e3f11f25e6f0271a002f13c64761b8b17985cde0e33651b951df";
+
+    let actual =
+        HashChecker::sha256sum("test/incomplete_wpa_supplicant-2XX2.9-8-x86_64.pkg.tar.zst");
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn test_check_api() {
+    let silent = true;
+    let expected = "0352bbf93e78e3f11f25e6f0271a002f13c64761b8b17985cde0e33651b951df";
+
+    let is_match = HashChecker::check(
+        "test/incomplete_wpa_supplicant-2XX2.9-8-x86_64.pkg.tar.zst",
+        expected,
+        silent,
+    );
+
+    assert!(is_match);
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -40,10 +40,9 @@ impl HashChecker {
 
 #[test]
 fn test_sha256sum_api() {
-    let expected = "0352bbf93e78e3f11f25e6f0271a002f13c64761b8b17985cde0e33651b951df";
+    let expected = "800dbea8f23421c6306df712af6f416a3f570ecf5652b45fd6d409019fe6d4fe";
 
-    let actual =
-        HashChecker::sha256sum("test/incomplete_wpa_supplicant-2XX2.9-8-x86_64.pkg.tar.zst");
+    let actual = HashChecker::sha256sum("LICENSE.md");
 
     assert_eq!(actual, expected);
 }
@@ -51,13 +50,9 @@ fn test_sha256sum_api() {
 #[test]
 fn test_check_api() {
     let silent = false;
-    let expected = "0352bbf93e78e3f11f25e6f0271a002f13c64761b8b17985cde0e33651b951df";
+    let expected = "800dbea8f23421c6306df712af6f416a3f570ecf5652b45fd6d409019fe6d4fe";
 
-    let is_match = HashChecker::check(
-        "test/incomplete_wpa_supplicant-2XX2.9-8-x86_64.pkg.tar.zst",
-        expected,
-        silent,
-    );
+    let is_match = HashChecker::check("LICENSE.md", expected, silent);
 
     assert!(is_match);
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -32,6 +32,7 @@ impl HashChecker {
 
         io::copy(&mut file, &mut hasher).unwrap();
         let computed_hash = hasher.finalize();
+        drop(file);
 
         format!("{:x}", computed_hash)
     }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -49,7 +49,7 @@ fn test_sha256sum_api() {
 
 #[test]
 fn test_check_api() {
-    let silent = true;
+    let silent = false;
     let expected = "0352bbf93e78e3f11f25e6f0271a002f13c64761b8b17985cde0e33651b951df";
 
     let is_match = HashChecker::check(


### PR DESCRIPTION
Using separate PR since hash mismatch broke `main`.