### PR TITLE
Revert "CI: No execution on wip label"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,19 +22,9 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check-labels:
-    name: Check labels
-    runs-on: ubuntu-latest
-    steps:
-      - uses: docker://agilepathway/pull-request-label-checker:latest
-        with:
-          none_of: wip
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     runs-on: ubuntu-latest
-    needs:
-      - check-labels
 
     steps:
     - uses: actions/checkout@v2
@@ -71,8 +61,6 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    needs:
-      - check-labels
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Reverts mihaigalos/aim#49 because it broke CI builds.