### PR TITLE
HTTPS: Fix PUT resume

### DIFF
--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -108,14 +108,14 @@ impl FTPHandler {
             .len();
 
         let parsed_address = ParsedAddress::parse_address(output, bar.silent);
-        let transfered = 0;
+        let transfered = 0; // TODO: get the remote file size to know where to restart from.
         let mut ftp_stream = FTPHandler::get_stream(transfered, &parsed_address)
             .await
             .expect("Cannot get stream");
         let mut reader_stream = ReaderStream::new(file);
 
         bar.set_length(total_size);
-        let mut uploaded = 0;
+        let mut uploaded = transfered;
 
         let async_stream = async_stream::stream! {
             while let Some(chunk) = reader_stream.next().await {

--- a/test/https/Justfile
+++ b/test/https/Justfile
@@ -108,7 +108,7 @@ _test_aim_put_resume_binary_file:
     test=$(basename $0) && source ../common.sh
     sha_input=$(sha256sum binary_file.tar.gz | cut -d' ' -f1)
     curl -s -X PUT --netrc-file .netrc.test_https --data-binary @binary_file.tar.gz.part1  http://127.0.0.1:{{ server_port }}/$test.tar.gz
-    aim -s binary_file.tar.gz.part2 http://127.0.0.1:8081/$test.tar.gz
+    aim -s binary_file.tar.gz http://127.0.0.1:8081/$test.tar.gz
     aim -s http://127.0.0.1:8081/$test.tar.gz $test
     sha_output=$(sha256sum $test | cut -d' ' -f1)
     [ "$sha_input" = "$sha_output" ] && ok || ok "ERROR: input and output SHA256s don't match."

--- a/test/https/nginx.conf
+++ b/test/https/nginx.conf
@@ -1,6 +1,14 @@
 server {
     listen 80;
 
+    proxy_request_buffering off;
+    proxy_buffering off; 
+    proxy_connect_timeout 180s;
+    proxy_send_timeout 180s;
+    proxy_read_timeout 180s;
+    fastcgi_send_timeout 180s;
+    fastcgi_read_timeout 180s;
+
     access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log info;
 


### PR DESCRIPTION
PUT resume was tested with 2 files: 1st file was put and then the 2nd one.
Since they had the same name, the upload was resumed.
This, however, does not guarantee that a full resume is possible, since getting the problem lies in the getting of the already uploaded bytes.

EDIT: Consider using `POST` to rewrite the file entirely (no resume possible).

Fixes: https://github.com/mihaigalos/aim/pull/57.