### PR TITLE
S3: Fix just tests

### DIFF
--- a/test/s3/Justfile
+++ b/test/s3/Justfile
@@ -33,6 +33,7 @@ _test_aim_put_binary_file:
     set -x
     sha_input=$(sha256sum test.file | cut -d' ' -f1)
     aim -s test.file s3://minioadmin:minioadmin@localhost:9000/test-bucket/$test
+    sleep 1
     aim -s s3://minioadmin:minioadmin@localhost:9000/test-bucket/$test $test
     sha_output=$(sha256sum $test | cut -d' ' -f1)
     [ "$sha_input" = "$sha_output" ] && ok || err "ERROR: input and output SHA256s don't match."


### PR DESCRIPTION
I suspect there is a small delay after a `PUT`  and immediate `GET` of the same file from a `Minio S3` bucket.
The bucket is probably still busy finishing off the request.
If this is actually true, might indicate a problem in `minio`.

### Logs
An empty file is hashed via `sha256`, yielding the hash `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`:
```bash
Running tests in /home/runner/work/aim/aim/test/s3
++ sha256sum test.file
++ cut '-d ' -f1
+ sha_input=f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2
+ aim -s test.file ***localhost:9000/test-bucket/_test_aim_put_binary_file
+ aim -s ***localhost:9000/test-bucket/_test_aim_put_binary_file _test_aim_put_binary_file
++ sha256sum _test_aim_put_binary_file
++ cut '-d ' -f1
+ sha_output=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+ '[' f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2 = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 ']'
+ err 'ERROR: input and output SHA256s don'\''t match.'
+ echo -e '\e[1;31mERROR: input and output SHA256s don'\''t match.\e[0m'
ERROR: input and output SHA256s don't match.
_test_aim_put_binary_file 
```