### PR TITLE
Add log coloring

### DIFF
--- a/.pipecolor.aim.toml
+++ b/.pipecolor.aim.toml
@@ -1,0 +1,6 @@
+[[lines]]
+    pat  = "^(.*?) - - .*? \\[(.*?)\\] (.*?) (.*?) (.*)"
+    colors = ["White", "LightGreen", "LightBlue", "LightYellow", "White", "LightGreen"]
+    [[lines.tokens]]
+        pat   = "Foo"
+        colors = ["LightCyan"]

--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ aim http://ip_of_Machine_A:8080/file . # download
 Moreover, since hosting is done over http, the client can even be a browser:
 ![hosting example](screenshots/self_hosting.png)
 
+The server prints logs to the standard output. To colorize them, you can use [pipecolor](https://github.com/dalance/pipecolor) with the provided `.pipecolor.aim.toml` in this repo:
+
+
+```bash
+aim /tmp | pipecolor -c ~/.pipecolor.aim.toml
+```
+![hosting example logs](screenshots/self_hosting_logs.png)
+
+
 ### Indicators
 By default, a progressbar is displayed when up/downloading. The indicators can be configured via the internally used [`indicatif`](https://crates.io/crates/indicatif) package.
 
@@ -198,5 +207,6 @@ Adapt IP to match that of machine `A`.
 docker run --rm -it -v $(pwd):/src --user $UID:$UID mihaigalos/aim http://192.168.0.24:8080/myfile /src/myfile
 ```
 ----------------------------------------
+
 ## 🛠️ Similar work
 [`duma`](https://github.com/mattgathu/duma), [`grapple`](https://github.com/daveallie/grapple), [`rget`](https://github.com/Arcterus/rget).

--- a/screenshots/self_hosting_logs.png
+++ b/screenshots/self_hosting_logs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a9bb164adc5f8639e0ac6f82d465d6e4eb34a4517b4ec02c3d21287564bc012
+size 6201


### PR DESCRIPTION
This PR adds log coloring to `aim` via [`pipecolor`](https://github.com/dalance/pipecolor) :
![image](https://user-images.githubusercontent.com/16443090/180598817-0fdc4b9c-77f1-46d7-ace6-565ff1861756.png)
