### PR TITLE
Audit: Update tolerated vulnerabilities

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,6 +4,6 @@
 [advisories]
 ignore = [
     "RUSTSEC-2020-0071",
-    "RUSTSEC-2020-0159",
-    "RUSTSEC-2021-0129"
+    "RUSTSEC-2021-0119",
+    "RUSTSEC-2021-0129",
 ]


### PR DESCRIPTION
Vulnerability `RUSTSEC-2021-0119` can be removed once https://github.com/lotabout/skim/issues/469 is closed.