### PR TITLE
Cargo: Migrate to dotenvy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "autoclap",
  "clap 4.0.13",
  "custom_error",
- "dotenv",
+ "dotenvy",
  "futures",
  "futures-util",
  "http",
@@ -947,10 +947,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "ed9155c8f4dc55c7470ae9da3f63c6785245093b3f6aeb0f5bf2e968efbba314"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ async_ftp = "6.0.0"
 autoclap = "0.3.5"
 clap = { version = "4.0.13", features = ["cargo", "string"] }
 custom_error = "1.9.2"
-dotenv = "0.15.0"
+dotenvy = "0.15.5"
 futures = "0.3"
 futures-util = "0.3.24"
 http = "0.2.8"

--- a/src/bar.rs
+++ b/src/bar.rs
@@ -1,4 +1,4 @@
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use std::collections::HashMap;
 use std::env;


### PR DESCRIPTION
The dotenv package is unmaintained.
[This](https://github.com/mihaigalos/aim/issues/127) suggest to use dotenvy instead.
